### PR TITLE
Add id in displayed attributes

### DIFF
--- a/meilisearch/feed_meilisearch.rb
+++ b/meilisearch/feed_meilisearch.rb
@@ -36,6 +36,7 @@ def load_data_into_meilisearch(documents)
       'summary'
     ],
     displayedAttributes: [
+      'id',
       'name',
       'summary',
       'description',


### PR DESCRIPTION
This prevents the dump bug -> https://github.com/meilisearch/MeiliSearch/issues/1241
With v0.19.0, MeiliSearch cannot know the existence of the `id` if it is not present in `displayedAttributes` during the dump creation.
This might be fixed in the future version.